### PR TITLE
Update convert_vcf_to_nexus.rb

### DIFF
--- a/species_tree_inference_with_snp_data/src/convert_vcf_to_nexus.rb
+++ b/species_tree_inference_with_snp_data/src/convert_vcf_to_nexus.rb
@@ -52,7 +52,7 @@ vcf_file.each do |l|
 		end
 		ids.size.times do |x|
 			gt = line_ary[9+x]
-			if gt.match(/([\d\.])\/|\|([\d\.])/)
+			if gt.match(/([\d\.])[\/|]([\d\.])/)
 				if $1 == "." and $2 == "."
 					sample_allele1 = "N"
 					sample_allele2 = "N"


### PR DESCRIPTION
Fix the regular expression to properly capture the digits or dots on both sides of the "/" or "|" character.